### PR TITLE
Add requirements file for easy install

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+fastapi==0.118.0
+feedparser==6.0.12
+matplotlib==3.10.6
+networkx==3.3
+pydantic==2.11.9
+pydantic_ai==1.0.13
+pymupdf==1.26.4
+python-dotenv==1.1.1
+Requests==2.32.5


### PR DESCRIPTION
Just a quick check - there's no `requirements.txt` file. Generated a quick one.